### PR TITLE
Add client remoteIP and remotePort to HttpRequest

### DIFF
--- a/examples/HttpServer/HttpServer.ino
+++ b/examples/HttpServer/HttpServer.ino
@@ -30,6 +30,8 @@ void loop() {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 void httpServerEvent(const HttpRequest &req, HttpResponse &res) {
+  Serial.print("client: ");
+  Serial.println(req.remoteIP);
   Serial.print("method: ");
   Serial.println(req.method);
   Serial.print("route: ");

--- a/src/HttpServer.cpp
+++ b/src/HttpServer.cpp
@@ -259,6 +259,11 @@ void HttpServer::update() {
     HttpRequest req;
     HttpResponse res(client);
 
+    if (client.connected()){
+      req.remoteIP = client.remoteIP();
+      req.remotePort = client.remotePort();
+    }
+
     // Parse the request
     // It is finished when all the data is received or when the connection is closed
     while (client.connected() && (section < FinishedSection)) {

--- a/src/HttpServer.cpp
+++ b/src/HttpServer.cpp
@@ -319,7 +319,7 @@ void HttpServer::update() {
             if ((c == '\r') || (c == ' ')) {
               // Ingore CR and spaces
             } else if (c == '\n') {
-              if (headerName.equalsIgnoreCase("Content-Length")) {
+              if (headerName.equalsIgnoreCase(F("Content-Length"))) {
                 contentLength = headerValue.toInt();
               }
               section = EmptyLineSection;

--- a/src/HttpServer.h
+++ b/src/HttpServer.h
@@ -22,6 +22,8 @@ class FormString : public String {
 };
 
 typedef struct {
+	IPAddress remoteIP;
+	uint16_t remotePort;
 	String method;
 	String route;
 	FormString queryString;


### PR DESCRIPTION
By adding this information to the HttpRequest struct, you can use it to logger it or other uses.
Better than adding a method to the HttpResponse class to return _client.remoteIP();